### PR TITLE
Order subpages using CSS

### DIFF
--- a/app/assets/stylesheets/components/_sub_nav.scss
+++ b/app/assets/stylesheets/components/_sub_nav.scss
@@ -8,6 +8,9 @@
     list-style-type: none;
     padding-left: 0;
     margin: 0;
+    display:flex;
+    flex-flow: row;
+    justify-content: center;
     li {
       display: inline-block;
       margin: 0 15px;

--- a/app/assets/stylesheets/components/_sub_page_list.scss
+++ b/app/assets/stylesheets/components/_sub_page_list.scss
@@ -1,15 +1,13 @@
 .sub_pages {
   margin-top: 75px;
+  display:flex;
+  flex-flow: column;
 
   .single_sub_page {
     border-top: 2px solid $black;
     margin-top: 45px;
     margin-bottom: 45px;
     padding-top: 45px;
-    &:last-child {
-      border-bottom: $border-width solid $black;
-      padding-bottom: 45px;
-    }
     .summary {
       margin-bottom: 15px;
     }

--- a/app/assets/stylesheets/components/_sub_page_ordering.scss
+++ b/app/assets/stylesheets/components/_sub_page_ordering.scss
@@ -1,0 +1,32 @@
+$subnavs: (
+  about-us: 1,
+  setting-up-the-centre: 2,
+  who-we-are: 3,
+  contact-us: 4,
+  working-with: 1,
+  whos-involved: 2,
+  what-you-told-us: 3,
+  co-designing-with-partners: 4,
+  evidence: 1,
+  research-topics: 2,
+  standard: 3,
+  outcomes-framework: 4,
+  evidence-store: 5
+);
+
+@each $key, $value in $subnavs {
+  .sub_nav ul li.#{$key} {
+    order: $value
+  }
+  
+  .sub_pages .single_sub_page.#{$key} {
+    order: $value
+  }
+}
+
+.sub_pages .single_sub_page {
+  &.contact-us, &.co-designing-with-partners, &.evidence-store {
+    border-bottom: $border-width solid $black;
+    padding-bottom: 45px;
+  }
+}

--- a/app/views/partials/sub_nav.haml
+++ b/app/views/partials/sub_nav.haml
@@ -3,5 +3,5 @@
     %li{ class: @page.nil? ? 'selected' : '' }
       = link_to @section.title, section_path(@section.slug)
     - @section.pages.sort_by(&:title).each do |p|
-      %li{ class: p.slug == @page&.slug ? 'selected' : '' }
+      %li{ class: p.slug == @page&.slug ? "selected #{p.slug}" : p.slug }
         = link_to p.title, section_page_path(@section.slug, p.slug)

--- a/app/views/sections/show.html.haml
+++ b/app/views/sections/show.html.haml
@@ -9,7 +9,7 @@
       .full_width.inner_container
         .sub_pages
           - @pages.each do |p|
-            .single_sub_page.inner_container
+            .single_sub_page.inner_container{ class: p.slug }
               .title_container
                 %h3=p.title
                 .summary= p.try(:summary)


### PR DESCRIPTION
I've gone through a couple of options to specify the order of pages, and I hit upon using css. Would welcome thoughts from @sm-ll and @evanschris to see if this isn't a massive misuse of tools!